### PR TITLE
Fix plugin.json manifest for Claude Code compatibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,6 @@
   },
   "homepage": "https://www.agentkits.net/marketing",
   "repository": "https://github.com/aitytech/agentkits-marketing",
-  "documentation": "https://www.agentkits.net/docs",
   "license": "MIT",
   "keywords": [
     "claude-code",
@@ -26,62 +25,5 @@
     "sales-enablement",
     "brand-building",
     "analytics"
-  ],
-  "category": "marketing",
-  "tags": [
-    "marketing",
-    "content",
-    "seo",
-    "cro",
-    "email",
-    "sales",
-    "campaigns",
-    "automation"
-  ],
-  "agents": "./.claude/agents",
-  "commands": "./.claude/commands",
-  "skills": "./.claude/skills",
-  "workflows": "./.claude/workflows",
-  "hooks": "./.claude/hooks",
-  "main": "CLAUDE.md",
-  "components": {
-    "agents": {
-      "path": "./.claude/agents",
-      "count": 18,
-      "categories": {
-        "core": ["attraction-specialist", "lead-qualifier", "email-wizard", "sales-enabler", "continuity-specialist", "upsell-maximizer"],
-        "supporting": ["researcher", "brainstormer", "planner", "project-manager", "copywriter", "docs-manager", "mcp-manager", "game-market-analyst"],
-        "reviewers": ["brand-voice-guardian", "conversion-optimizer", "seo-specialist", "solopreneur", "startup-founder"]
-      }
-    },
-    "commands": {
-      "path": "./.claude/commands",
-      "count": 93,
-      "categories": ["campaign", "content", "seo", "cro", "social", "sequence", "analytics", "report", "sales", "leads", "crm", "brand", "ops", "research", "competitor", "growth", "pricing", "marketing", "test", "audit", "game", "training"]
-    },
-    "skills": {
-      "path": "./.claude/skills",
-      "count": 28,
-      "categories": {
-        "core": ["marketing-fundamentals", "marketing-psychology", "marketing-ideas", "seo-mastery", "social-media", "email-marketing", "paid-advertising", "content-strategy", "analytics-attribution", "brand-building", "problem-solving"],
-        "cro": ["page-cro", "form-cro", "popup-cro", "signup-flow-cro", "onboarding-cro", "paywall-upgrade-cro", "ab-test-setup"],
-        "content": ["copywriting", "copy-editing", "email-sequence"],
-        "seo-growth": ["programmatic-seo", "schema-markup", "competitor-alternatives", "launch-strategy", "pricing-strategy", "referral-program", "free-tool-strategy"],
-        "specialized": ["document-skills", "game-marketing"]
-      }
-    },
-    "workflows": {
-      "path": "./.claude/workflows",
-      "files": ["primary-workflow.md", "sales-workflow.md", "crm-workflow.md", "marketing-rules.md", "orchestration-protocol.md", "documentation-management.md", "data-reliability-rules.md", "game-marketing-workflow.md"]
-    }
-  },
-  "features": {
-    "multiLanguage": true,
-    "mcpIntegrations": ["sensortower", "google-search-console", "google-analytics", "semrush", "dataforseo", "meta-ads", "hubspot", "slack", "notion", "asana"],
-    "training": true,
-    "trainingModules": 19
-  },
-  "requirements": {
-    "claudeCode": ">=1.0.0"
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

- Removes fields from `plugin.json` that are not part of the Claude Code plugin manifest schema, preventing installation
- Removed invalid keys: `documentation`, `category`, `tags`, `workflows`, `main`, `components`, `features`, `requirements`
- Removed string-path declarations for `hooks`, `agents`, `commands`, `skills` (Claude Code auto-discovers these from `.claude/` directories)

Fixes #8

## Context

Installing the plugin fails with:

```
Error: Failed to install: Plugin has an invalid manifest file at .claude-plugin/plugin.json.
Validation errors: hooks: Invalid input, agents: Invalid input, : Unrecognized keys:
"documentation", "category", "tags", "workflows", "main", "components", "features", "requirements"
```

The fix aligns the manifest with the format used by working plugins (e.g. [superpowers](https://github.com/obra/superpowers), [claude-plugins-official](https://github.com/anthropics/claude-plugins-official)).