### PR TITLE
fix: plugin installation fails in Claude Code Desktop (#17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "agentkits-marketing",
-      "source": "./",
+      "source": "../",
       "description": "Full marketing automation suite - agents, commands, skills, workflows, and training",
       "category": "marketing",
       "tags": [
@@ -30,7 +30,7 @@
     },
     {
       "name": "agentkits-marketing-skills",
-      "source": "./.claude/skills",
+      "source": "../.claude/skills",
       "description": "28 marketing skills including CRO, SEO, copywriting, psychology, and growth",
       "category": "skills",
       "tags": [
@@ -40,7 +40,7 @@
     },
     {
       "name": "agentkits-marketing-agents",
-      "source": "./.claude/agents",
+      "source": "../.claude/agents",
       "description": "18 specialized marketing agents for campaigns, content, and optimization",
       "category": "agents",
       "tags": [
@@ -50,7 +50,7 @@
     },
     {
       "name": "agentkits-marketing-commands",
-      "source": "./.claude/commands",
+      "source": "../.claude/commands",
       "description": "90+ marketing slash commands for campaigns, content, SEO, CRO, and analytics",
       "category": "commands",
       "tags": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,9 +2,9 @@
   "name": "agentkits-marketing",
   "version": "1.7.1",
   "description": "Enterprise-grade AI marketing automation framework - 18 agents, 90+ commands, 28 skills for campaigns, content, SEO, and conversion optimization",
-  "commands": "./.claude/commands",
-  "skills": "./.claude/skills",
-  "agents": "./.claude/agents",
+  "commands": "../.claude/commands",
+  "skills": "../.claude/skills",
+  "agents": "../.claude/agents",
   "author": {
     "name": "AityTech",
     "url": "https://www.agentkits.net"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "snyk.advanced.organization": "81a367e5-0098-421b-b05c-0f8a952dfc76",
+  "snyk.advanced.autoSelectOrganization": true
+}


### PR DESCRIPTION
## Summary
- Fix plugin path resolution in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- Paths were resolving relative to `.claude-plugin/` directory but pointed to repo root paths, causing "Failed to install plugin" error

## Changes
- `.claude-plugin/plugin.json`: Changed `"./.claude/..."` → `"../.claude/..."` for commands, skills, agents paths
- `.claude-plugin/marketplace.json`: Changed `source` paths from `"./"` → `"../"` and `"./.claude/..."` → `"../.claude/..."`

## Root Cause
Plugin discovery worked (marketplace loaded correctly), but installation failed because paths resolved relative to `.claude-plugin/` directory, pointing to non-existent locations like `.claude-plugin/.claude/commands/`.

Fixes #17