### PR TITLE
fix: align plugin manifests with Claude Code Desktop spec (#17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,61 +2,60 @@
   "name": "agentkits-marketing",
   "owner": {
     "name": "AityTech",
-    "email": "contact@agentkits.net",
-    "url": "https://agentkits.net"
+    "email": "contact@agentkits.net"
   },
   "metadata": {
     "description": "AI marketing agent tools by AityTech",
-    "longDescription": "Complete marketing automation suite with 18 specialized agents, 90+ slash commands, 28 marketing skills, and interactive training. Covers campaigns, content, SEO, CRO, email, sales enablement, and analytics.",
-    "version": "1.7.1",
-    "updatedAt": "2026-02-27"
+    "version": "1.7.1"
   },
   "plugins": [
     {
       "name": "agentkits-marketing",
-      "source": "../",
-      "description": "Full marketing automation suite - agents, commands, skills, workflows, and training",
+      "source": "./",
+      "description": "Full marketing automation suite - 18 agents, 90+ commands, 28 skills, workflows, and training",
+      "version": "1.7.1",
+      "author": {
+        "name": "AityTech"
+      },
+      "homepage": "https://www.agentkits.net/marketing",
+      "repository": "https://github.com/aitytech/agentkits-marketing",
+      "license": "MIT",
+      "commands": [".claude/commands"],
+      "agents": [".claude/agents"],
+      "skills": [".claude/skills"],
+      "strict": false,
       "category": "marketing",
-      "tags": [
-        "marketing",
-        "content",
-        "seo",
-        "cro",
-        "email",
-        "sales",
-        "campaigns",
-        "automation"
-      ]
+      "tags": ["marketing", "content", "seo", "cro", "email", "sales", "campaigns", "automation"]
     },
     {
       "name": "agentkits-marketing-skills",
-      "source": "../.claude/skills",
+      "source": "./",
       "description": "28 marketing skills including CRO, SEO, copywriting, psychology, and growth",
+      "version": "1.7.1",
+      "skills": [".claude/skills"],
+      "strict": false,
       "category": "skills",
-      "tags": [
-        "skills",
-        "marketing"
-      ]
+      "tags": ["skills", "marketing"]
     },
     {
       "name": "agentkits-marketing-agents",
-      "source": "../.claude/agents",
+      "source": "./",
       "description": "18 specialized marketing agents for campaigns, content, and optimization",
+      "version": "1.7.1",
+      "agents": [".claude/agents"],
+      "strict": false,
       "category": "agents",
-      "tags": [
-        "agents",
-        "marketing"
-      ]
+      "tags": ["agents", "marketing"]
     },
     {
       "name": "agentkits-marketing-commands",
-      "source": "../.claude/commands",
+      "source": "./",
       "description": "90+ marketing slash commands for campaigns, content, SEO, CRO, and analytics",
+      "version": "1.7.1",
+      "commands": [".claude/commands"],
+      "strict": false,
       "category": "commands",
-      "tags": [
-        "commands",
-        "marketing"
-      ]
+      "tags": ["commands", "marketing"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,9 +2,6 @@
   "name": "agentkits-marketing",
   "version": "1.7.1",
   "description": "Enterprise-grade AI marketing automation framework - 18 agents, 90+ commands, 28 skills for campaigns, content, SEO, and conversion optimization",
-  "commands": "../.claude/commands",
-  "skills": "../.claude/skills",
-  "agents": "../.claude/agents",
   "author": {
     "name": "AityTech",
     "url": "https://www.agentkits.net"

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,40 +1,31 @@
 {
   "name": "agentkits-marketing",
   "owner": {
-    "name": "AgentKits Team (AityTech)",
+    "name": "AityTech",
     "email": "contact@agentkits.net"
   },
   "metadata": {
-    "description": "Enterprise-grade AI marketing automation framework for Claude Code"
+    "description": "Enterprise-grade AI marketing automation framework for Claude Code",
+    "version": "1.7.1"
   },
   "plugins": [
     {
       "name": "agentkits-marketing",
       "source": "./",
-      "description": "Full marketing automation suite with 18 agents, 90+ commands, 28 skills",
+      "description": "Full marketing automation suite - 18 agents, 90+ commands, 28 skills",
+      "version": "1.7.1",
       "author": {
-        "name": "AgentKits Team (AityTech)"
+        "name": "AityTech"
       },
-      "homepage": "https://agentkits.net",
+      "homepage": "https://www.agentkits.net/marketing",
       "repository": "https://github.com/aitytech/agentkits-marketing",
       "license": "MIT",
-      "keywords": [
-        "marketing",
-        "ai-agents",
-        "content",
-        "seo",
-        "cro",
-        "email",
-        "campaigns"
-      ],
+      "commands": [".claude/commands"],
+      "agents": [".claude/agents"],
+      "skills": [".claude/skills"],
+      "strict": false,
       "category": "marketing",
-      "tags": [
-        "marketing",
-        "content",
-        "seo",
-        "cro",
-        "automation"
-      ]
+      "tags": ["marketing", "content", "seo", "cro", "automation"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixes "Failed to add marketplace" and "Failed to install plugin" errors in Claude Code Desktop
- Previous fix used `../` paths which are blocked by Claude Code ("Path traversal not allowed")

## Root Cause
Claude Code Desktop expects:
1. Plugin components (`commands/`, `agents/`, `skills/`) at plugin root level
2. Our files live at `.claude/commands/`, `.claude/agents/`, `.claude/skills/`
3. Custom paths must be declared in **marketplace entries** using `strict: false`

## Changes
- **`plugin.json`**: Removed non-standard `commands`/`skills`/`agents` fields (only standard manifest fields)
- **`marketplace.json`**: Added `strict: false` + explicit component paths (`".claude/commands"` etc.)
- **`marketplace.json`**: All sub-plugins now use `source: "./"` with explicit component declarations
- **Root `marketplace.json`**: Same fixes applied

Fixes #17