### PR TITLE
chore(release): bump version to 1.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "AI marketing agent tools by AityTech",
-    "version": "1.7.1"
+    "version": "1.7.2"
   },
   "plugins": [
     {
       "name": "agentkits-marketing",
       "source": "./",
       "description": "Full marketing automation suite - 20 agents, 90+ commands, 28 skills, workflows, and training",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "author": {
         "name": "AityTech"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkits-marketing",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Enterprise-grade AI marketing automation framework - 18 agents, 90+ commands, 28 skills for campaigns, content, SEO, and conversion optimization",
   "author": {
     "name": "AityTech",

--- a/.claude/metadata.json
+++ b/.claude/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.1",
+  "version": "1.7.2",
   "name": "@aitytech/agentkits-marketing",
   "description": "Enterprise-grade AI marketing automation for Claude Code, Cursor, GitHub Copilot, Windsurf, Cline. 18 agents, 93 commands, 28 skills. One command: npx agentkits-marketing install",
   "buildDate": "2026-02-27T14:01:54.615Z",

--- a/marketplace.json
+++ b/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Enterprise-grade AI marketing automation framework for Claude Code",
-    "version": "1.7.1"
+    "version": "1.7.2"
   },
   "plugins": [
     {
       "name": "agentkits-marketing",
       "source": "./",
       "description": "Full marketing automation suite - 20 agents, 90+ commands, 28 skills",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "author": {
         "name": "AityTech"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aitytech/agentkits-marketing",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Enterprise-grade AI marketing automation for Claude Code, Cursor, GitHub Copilot, Windsurf, Cline. 18 agents, 93 commands, 28 skills. One command: npx agentkits-marketing install",
   "main": "bin/agentkits.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 1.7.2 across all manifest files (package.json, plugin.json, marketplace.json, metadata.json)
- Prepares for npm publish with the plugin structure fix from PR #25