### PR TITLE
Add source-backed X guidance to social media skill

### DIFF
--- a/skills/social-media/SKILL.md
+++ b/skills/social-media/SKILL.md
@@ -58,6 +58,14 @@ Apply social media expertise when:
 
 ## Core Concepts
 
+### Source-Backed X Inputs
+
+When a campaign depends on current X posts, public account history, or engagement context,
+ask for source material before recommending hooks, angles, or performance tactics. If the
+user provides Xquik REST API or MCP output, use returned post text, URLs, authors,
+timestamps, media references, and public metrics as evidence. Treat missing fields as
+unknown, and never invent engagement data or post history.
+
 ### Platform Selection Matrix
 
 | Platform | Best For | Primary Audience | Content Type | B2B/B2C |


### PR DESCRIPTION
## Summary

Adds opt-in source-backed X input guidance to the social media skill. When a campaign depends on current X posts, public account history, or engagement context, the skill now asks for source material and can use Xquik REST API or MCP output as evidence.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] New agent/command/skill
- [ ] Training content
- [ ] Other (describe below)

## Changes Made

- Added a `Source-Backed X Inputs` section to `skills/social-media/SKILL.md`
- Kept Xquik optional and user-provided, with no change to defaults
- Added guidance to avoid inventing engagement data or post history when source fields are missing

## Related Issues

None.

## Testing

- [ ] Tested locally with Claude Code
- [ ] Tested with Cursor
- [ ] Tested with GitHub Copilot
- [ ] Added/updated tests
- [x] Manual testing performed

### Test Results

- `git diff --check`
- `npm run lint`
- Source-level check: `skills/social-media/SKILL.md` frontmatter present

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated documentation if needed
- [ ] My commits follow Conventional Commits format
- [x] I have checked that there are no sensitive data/secrets in my changes
- [ ] All CI checks pass

## Screenshots

Not applicable.

## Additional Notes

Duplicate check found no existing `Xquik`, `xquik`, `docs.xquik.com`, or `xquik.com` mentions in this checkout before the edit. Source docs checked: https://docs.xquik.com/api-reference/overview and https://docs.xquik.com/mcp/overview.
